### PR TITLE
Fix code scanning alert no. 25: Clear-text logging of sensitive information

### DIFF
--- a/package/flatpack/flatpack/main.py
+++ b/package/flatpack/flatpack/main.py
@@ -3556,12 +3556,12 @@ def fpk_cli_handle_run(args, session):
                 console.print("[bold red]Please answer YES or NO.[/bold red]")
 
     secret_key = get_secret_key()
-    logger.info("[CSRF] New secret key generated for this session: %s", secret_key)
-    console.print(f"[CSRF] New secret key generated for this session: {secret_key}", style="bold blue")
+    logger.info("[CSRF] New secret key generated for this session.")
+    console.print("[CSRF] New secret key generated for this session.", style="bold blue")
 
     csrf_token_base = secrets.token_urlsafe(32)
-    logger.info("[CSRF] New token generated for this session: %s", csrf_token_base)
-    console.print(f"[CSRF] New token generated for this session: {csrf_token_base}", style="bold blue")
+    logger.info("[CSRF] New token generated for this session.")
+    console.print("[CSRF] New token generated for this session.", style="bold blue")
 
     console.print("")
 


### PR DESCRIPTION
Fixes [https://github.com/RomlinGroup/Flatpack/security/code-scanning/25](https://github.com/RomlinGroup/Flatpack/security/code-scanning/25)

To fix the problem, we need to ensure that sensitive information such as the `secret_key` is not logged in clear text. Instead, we can log a generic message indicating that a secret key was generated without including the actual key. This approach maintains the functionality of logging events without exposing sensitive data.

1. Identify the lines where sensitive information is logged.
2. Replace the logging of sensitive data with a generic message.
3. Ensure that the console output also does not display sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
