### PR TITLE
Fix code scanning alert no. 38: Uncontrolled data used in path expression

### DIFF
--- a/package/flatpack/flatpack/main.py
+++ b/package/flatpack/flatpack/main.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from pathlib import Path
+from werkzeug.utils import secure_filename
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -3354,7 +3355,8 @@ def setup_routes(app):
         if not flatpack_directory:
             raise HTTPException(status_code=500, detail="Flatpack directory is not set")
 
-        file_path = os.path.join(flatpack_directory, 'build', filename)
+        sanitized_filename = secure_filename(filename)
+        file_path = os.path.join(flatpack_directory, 'build', sanitized_filename)
 
         if not os.path.commonpath([flatpack_directory, os.path.realpath(file_path)]).startswith(
                 os.path.realpath(flatpack_directory)):


### PR DESCRIPTION
Fixes [https://github.com/RomlinGroup/Flatpack/security/code-scanning/38](https://github.com/RomlinGroup/Flatpack/security/code-scanning/38)

To fix the problem, we need to ensure that the `filename` provided by the user is sanitized and validated before constructing the `file_path`. We can use the `werkzeug.utils.secure_filename` function to sanitize the `filename` and ensure it does not contain any special characters or sequences that could lead to path traversal attacks.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the `filename` before constructing the `file_path`.
3. Ensure that the `file_path` is still within the `flatpack_directory` after sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
